### PR TITLE
[DP-640] Spark에서 location 활용을 위한 location converter 추가

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/CatalogToHiveConverter.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/CatalogToHiveConverter.java
@@ -40,6 +40,7 @@ import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_TABLE_N
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_DB_NAME;
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_HANDLER_CLASS;
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_ORIGIN_TABLE_NAME;
+import static com.amazonaws.glue.catalog.converters.ConverterUtils.convertLocationScheme;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
@@ -171,7 +172,7 @@ public class CatalogToHiveConverter {
   public static StorageDescriptor convertStorageDescriptor(com.amazonaws.services.glue.model.StorageDescriptor catalogSd) {
     StorageDescriptor hiveSd = new StorageDescriptor();
     hiveSd.setCols(convertFieldSchemaList(catalogSd.getColumns()));
-    hiveSd.setLocation(catalogSd.getLocation());
+    hiveSd.setLocation(convertLocationScheme(catalogSd.getLocation(), "s3a"));
     hiveSd.setInputFormat(catalogSd.getInputFormat());
     hiveSd.setOutputFormat(catalogSd.getOutputFormat());
     hiveSd.setCompressed(catalogSd.getCompressed());

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/ConverterUtils.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/ConverterUtils.java
@@ -1,5 +1,6 @@
 package com.amazonaws.glue.catalog.converters;
 
+import org.apache.commons.lang3.StringUtils;
 import com.amazonaws.services.glue.model.Table;
 
 import com.google.gson.Gson;
@@ -19,5 +20,11 @@ public class ConverterUtils {
 
   public static Table stringToCatalogTable(final String input) {
     return gson.fromJson(input, Table.class);
+  }
+
+  // XXX(kimtkyeom): 현재는 묻지도 따지지도 않고 s3 와 s3a 사이로 location을 변환한다. (각 converter의 convertStorageDescriptor 참조)
+  // upstream merge가 가능하려면 MetastoreConverter나 Glue <-> Hive converter 사이에서 configurable한 형태가 되어야 하지 않을까..
+  public static String convertLocationScheme(String location, String targetScheme) {
+    return String.format("%s://%s", targetScheme, StringUtils.substringAfter(location, "://"));
   }
 }

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/HiveToCatalogConverter.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/HiveToCatalogConverter.java
@@ -23,6 +23,7 @@ import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_DEFERRE
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_HANDLER_CLASS;
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_ORIGIN_TABLE_NAME;
 import static com.amazonaws.glue.catalog.converters.ConverterUtils.INDEX_TABLE_NAME;
+import static com.amazonaws.glue.catalog.converters.ConverterUtils.convertLocationScheme;
 
 public class HiveToCatalogConverter {
 
@@ -63,7 +64,7 @@ public class HiveToCatalogConverter {
     catalogSd.setBucketColumns(hiveSd.getBucketCols());
     catalogSd.setColumns(convertFieldSchemaList(hiveSd.getCols()));
     catalogSd.setInputFormat(hiveSd.getInputFormat());
-    catalogSd.setLocation(hiveSd.getLocation());
+    catalogSd.setLocation(convertLocationScheme(hiveSd.getLocation(), "s3"));
     catalogSd.setOutputFormat(hiveSd.getOutputFormat());
     catalogSd.setSerdeInfo(convertSerDeInfo(hiveSd.getSerdeInfo()));
     catalogSd.setSkewedInfo(convertSkewedInfo(hiveSd.getSkewedInfo()));


### PR DESCRIPTION
## 변경사항
Spark의 external catalog는 file location을 찾을 때 Storage descriptor의 location을 기반으로 file location을 구성한다. 따라서 s3 scheme을 가지고 있을 경우 동작하지 않는다.

기존 aws-glue-data-catalog의 경우 StorageDescriptor의 location이 s3 scheme으로 기입되어있어 spark에서 제대로 활용하기 어려워 이를 수정함.

* glue -> hive conversion: target scheme을 s3a로 설정하여 location을 s3 에서 s3a로 변환
* hive -> glue: 현재는 활용하고 있지 않지만 glue에 변화를 줘야 할 때 (alter / create 등) location은 s3로 변환되어야 하므로 target scheme을 s3로 변경

## 기타
* 현재 구조는 단순하게 s3 <-> s3a scheme을 변환하는 로직을 가지고 있다. 만약 upstream merge를 가정한다면 단순히 주소를 바꾸는 것이 아닌 configurable한 구성이 되어야 할 수 있음. 이러한 부분에서 더 나은 구현 방향에 대한 의견이 있으면 조언 부탁드립니다.

## Future works (maybe?)
* Test update: 기존 테스트는 location이 모두 s3 scheme임을 가정하고 작성되어있으므로 테스트가 제대로 동작하도록 하기 위해서는 영향 받는 테스트를 전부 업데이트 해야 한다.