### PR TITLE
[DP-1312] Hive / Hadoop dependency update, upstream 변경 사항 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Similarly, for Spark, you need to install the client jar in Spark's CLASSPATH an
 Currently, we provide support for caching:
 
 a) Table metadata - Response from Glue's GetTable operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetTable.html#API_GetTable_ResponseSyntax)
+
 b) Database metadata - Response from Glue's GetDatabase operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabase.html#API_GetDatabase_ResponseSyntax)
 
 Both these entities have dedicated caches for themselves and can be enabled/tuned individually.
@@ -104,7 +105,7 @@ To enable/tune Database cache:
  		<value>30</value>
 	</property>
 
-NOTE: The caching logic is disabled by default.
+NOTE: The caching logic is disabled by default. Also, there is no one-size-fits-all value for the cache size and ttl; feel free to tune these values as per your use case.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,47 @@ You need to ensure that the AWS Glue Data Catalog Client jar is in Hive's CLASSP
 
 Similarly, for Spark, you need to install the client jar in Spark's CLASSPATH and create or update Spark's own hive-site.xml to add the above property.  On Amazon EMR, this is set in /usr/lib/spark/conf/hive-site.xml.  You can also find the location of the Spark client jar in /usr/lib/spark/conf/spark-defaults.conf.
 
+## Enabling client side caching for catalog
+
+Currently, we provide support for caching:
+
+a) Table metadata - Response from Glue's GetTable operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetTable.html#API_GetTable_ResponseSyntax)
+b) Database metadata - Response from Glue's GetDatabase operation (https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabase.html#API_GetDatabase_ResponseSyntax)
+
+Both these entities have dedicated caches for themselves and can be enabled/tuned individually.
+
+To enable/tune Table cache, use the following properties in your hive/spark configuration file:
+
+	<property>
+ 		<name>aws.glue.cache.table.enable</name>
+ 		<value>true</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.table.size</name>
+ 		<value>1000</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.table.ttl-mins</name>
+ 		<value>30</value>
+	</property>
+
+To enable/tune Database cache:
+
+	<property>
+ 		<name>aws.glue.cache.db.enable</name>
+ 		<value>true</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.db.size</name>
+ 		<value>1000</value>
+	</property>
+	<property>
+ 		<name>aws.glue.cache.db.ttl-mins</name>
+ 		<value>30</value>
+	</property>
+
+NOTE: The caching logic is disabled by default.
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 

--- a/aws-glue-datacatalog-client-common/pom.xml
+++ b/aws-glue-datacatalog-client-common/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>shims-loader</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/GlueInputConverter.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/converters/GlueInputConverter.java
@@ -71,7 +71,7 @@ public final class GlueInputConverter {
     return partitionInput;
   }
 
-  public static Collection<PartitionInput> convertToPartitionInputs(Collection<com.amazonaws.services.glue.model.Partition> parts) {
+  public static List<PartitionInput> convertToPartitionInputs(Collection<com.amazonaws.services.glue.model.Partition> parts) {
     List<PartitionInput> inputList = new ArrayList<>();
 
     for (com.amazonaws.services.glue.model.Partition part : parts) {

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastore.java
@@ -1,0 +1,74 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.thrift.TException;
+
+import java.util.List;
+
+/**
+ * This is the accessor interface for using AWS Glue as a metastore.
+ * The generic AWSGlue interface{@link com.amazonaws.services.glue.AWSGlue}
+ * has a number of methods that are irrelevant for clients using Glue only
+ * as a metastore.
+ * Think of this interface as a wrapper over AWSGlue. This additional layer
+ * of abstraction achieves the following -
+ * a) Hides the non-metastore related operations present in AWSGlue
+ * b) Hides away the batching and pagination related limitations of AWSGlue
+ */
+public interface AWSGlueMetastore {
+
+    void createDatabase(DatabaseInput databaseInput);
+
+    Database getDatabase(String dbName);
+
+    List<Database> getAllDatabases();
+
+    void updateDatabase(String databaseName, DatabaseInput databaseInput);
+
+    void deleteDatabase(String dbName);
+
+    void createTable(String dbName, TableInput tableInput);
+
+    Table getTable(String dbName, String tableName);
+
+    List<Table> getTables(String dbname, String tablePattern);
+
+    void updateTable(String dbName, TableInput tableInput);
+
+    void deleteTable(String dbName, String tableName);
+
+    Partition getPartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                         List<PartitionValueList> partitionsToGet);
+
+    List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                  long max) throws TException;
+
+    void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                         PartitionInput partitionInput);
+
+    void deletePartition(String dbName, String tableName, List<String> partitionValues);
+
+    List<PartitionError> createPartitions(String dbName, String tableName,
+                                          List<PartitionInput> partitionInputs);
+
+    void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput);
+
+    UserDefinedFunction getUserDefinedFunction(String dbName, String functionName);
+
+    List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern);
+
+    void deleteUserDefinedFunction(String dbName, String functionName);
+
+    void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput);
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreBaseDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreBaseDecorator.java
@@ -1,0 +1,133 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import org.apache.thrift.TException;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AWSGlueMetastoreBaseDecorator implements AWSGlueMetastore {
+
+    private final AWSGlueMetastore awsGlueMetastore;
+
+    public AWSGlueMetastoreBaseDecorator(AWSGlueMetastore awsGlueMetastore) {
+        checkNotNull(awsGlueMetastore, "awsGlueMetastore can not be null");
+        this.awsGlueMetastore = awsGlueMetastore;
+    }
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        awsGlueMetastore.createDatabase(databaseInput);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        return awsGlueMetastore.getDatabase(dbName);
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        return awsGlueMetastore.getAllDatabases();
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        awsGlueMetastore.updateDatabase(databaseName, databaseInput);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        awsGlueMetastore.deleteDatabase(dbName);
+    }
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.createTable(dbName, tableInput);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        return awsGlueMetastore.getTable(dbName, tableName);
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        return awsGlueMetastore.getTables(dbname, tablePattern);
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        awsGlueMetastore.updateTable(dbName, tableInput);
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        awsGlueMetastore.deleteTable(dbName, tableName);
+    }
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        return awsGlueMetastore.getPartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName, List<PartitionValueList> partitionsToGet) {
+        return awsGlueMetastore.getPartitionsByNames(dbName, tableName, partitionsToGet);
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression, long max) throws TException {
+        return awsGlueMetastore.getPartitions(dbName, tableName, expression, max);
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues, PartitionInput partitionInput) {
+        awsGlueMetastore.updatePartition(dbName, tableName, partitionValues, partitionInput);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        awsGlueMetastore.deletePartition(dbName, tableName, partitionValues);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName, List<PartitionInput> partitionInputs) {
+        return awsGlueMetastore.createPartitions(dbName, tableName, partitionInputs);
+    }
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.createUserDefinedFunction(dbName, functionInput);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        return awsGlueMetastore.getUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        return awsGlueMetastore.getUserDefinedFunctions(dbName, pattern);
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        awsGlueMetastore.deleteUserDefinedFunction(dbName, functionName);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        awsGlueMetastore.updateUserDefinedFunction(dbName, functionName, functionInput);
+    }
+
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecorator.java
@@ -1,0 +1,164 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Table;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.log4j.Logger;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AWSGlueMetastoreCacheDecorator extends AWSGlueMetastoreBaseDecorator {
+
+    private static final Logger logger = Logger.getLogger(AWSGlueMetastoreCacheDecorator.class);
+
+    private final HiveConf conf;
+
+    private final boolean databaseCacheEnabled;
+
+    private final boolean tableCacheEnabled;
+
+    @VisibleForTesting
+    protected Cache<String, Database> databaseCache;
+    @VisibleForTesting
+    protected Cache<TableIdentifier, Table> tableCache;
+
+    public AWSGlueMetastoreCacheDecorator(HiveConf conf, AWSGlueMetastore awsGlueMetastore) {
+        super(awsGlueMetastore);
+
+        checkNotNull(conf, "conf can not be null");
+        this.conf = conf;
+
+        databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        if(databaseCacheEnabled) {
+            int dbCacheSize = conf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0);
+            int dbCacheTtlMins = conf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_SIZE, dbCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_DB_CACHE_TTL_MINS, dbCacheTtlMins);
+
+            //initialize database cache
+            databaseCache = CacheBuilder.newBuilder().maximumSize(dbCacheSize)
+                    .expireAfterWrite(dbCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            databaseCache = null;
+        }
+
+        tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        if(tableCacheEnabled) {
+            int tableCacheSize = conf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0);
+            int tableCacheTtlMins = conf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0);
+
+            //validate config values for size and ttl
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_SIZE, tableCacheSize);
+            validateConfigValueIsGreaterThanZero(AWS_GLUE_TABLE_CACHE_TTL_MINS, tableCacheTtlMins);
+
+            //initialize table cache
+            tableCache = CacheBuilder.newBuilder().maximumSize(tableCacheSize)
+                    .expireAfterWrite(tableCacheTtlMins, TimeUnit.MINUTES).build();
+        } else {
+            tableCache = null;
+        }
+
+        logger.info("Constructed");
+    }
+
+    private void validateConfigValueIsGreaterThanZero(String configName, int value) {
+        checkArgument(value > 0, String.format("Invalid value for Hive Config %s. " +
+                "Provide a value greater than zero", configName));
+
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        Database result;
+        if(databaseCacheEnabled) {
+            Database valueFromCache = databaseCache.getIfPresent(dbName);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getDatabase] on key [" + dbName + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getDatabase] on key [" + dbName + "]");
+                result = super.getDatabase(dbName);
+                databaseCache.put(dbName, result);
+            }
+        } else {
+            result = super.getDatabase(dbName);
+        }
+        return result;
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        Table result;
+        if(tableCacheEnabled) {
+            TableIdentifier key = new TableIdentifier(dbName, tableName);
+            Table valueFromCache = tableCache.getIfPresent(key);
+            if(valueFromCache != null) {
+                logger.info("Cache hit for operation [getTable] on key [" + key + "]");
+                result = valueFromCache;
+            } else {
+                logger.info("Cache miss for operation [getTable] on key [" + key + "]");
+                result = super.getTable(dbName, tableName);
+                tableCache.put(key, result);
+            }
+        } else {
+            result = super.getTable(dbName, tableName);
+        }
+        return result;
+    }
+
+    static class TableIdentifier {
+        private final String dbName;
+        private final String tableName;
+
+        public TableIdentifier(String dbName, String tableName) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+        }
+
+        public String getDbName() {
+            return dbName;
+        }
+
+        public String getTableName() {
+            return tableName;
+        }
+
+        @Override
+        public String toString() {
+            return "TableIdentifier{" +
+                    "dbName='" + dbName + '\'' +
+                    ", tableName='" + tableName + '\'' +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TableIdentifier that = (TableIdentifier) o;
+            return Objects.equals(dbName, that.dbName) &&
+                    Objects.equals(tableName, that.tableName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tableName);
+        }
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactory.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactory.java
@@ -1,0 +1,26 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.AWSGlue;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+
+public class AWSGlueMetastoreFactory {
+
+    public AWSGlueMetastore newMetastore(HiveConf conf) throws MetaException {
+        AWSGlue glueClient = new AWSGlueClientFactory(conf).newClient();
+        AWSGlueMetastore defaultMetastore = new DefaultAWSGlueMetastore(conf, glueClient);
+        if(isCacheEnabled(conf)) {
+            return new AWSGlueMetastoreCacheDecorator(conf, defaultMetastore);
+        }
+        return defaultMetastore;
+    }
+
+    private boolean isCacheEnabled(HiveConf conf) {
+        boolean databaseCacheEnabled = conf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        boolean tableCacheEnabled = conf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+        return (databaseCacheEnabled || tableCacheEnabled);
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/DefaultAWSGlueMetastore.java
@@ -1,0 +1,407 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.glue.catalog.util.MetastoreClientUtils;
+import com.amazonaws.services.glue.AWSGlue;
+import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionRequest;
+import com.amazonaws.services.glue.model.BatchGetPartitionResult;
+import com.amazonaws.services.glue.model.CreateDatabaseRequest;
+import com.amazonaws.services.glue.model.CreateTableRequest;
+import com.amazonaws.services.glue.model.CreateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.DatabaseInput;
+import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.amazonaws.services.glue.model.DeletePartitionRequest;
+import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.DeleteUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetDatabaseRequest;
+import com.amazonaws.services.glue.model.GetDatabaseResult;
+import com.amazonaws.services.glue.model.GetDatabasesRequest;
+import com.amazonaws.services.glue.model.GetDatabasesResult;
+import com.amazonaws.services.glue.model.GetPartitionRequest;
+import com.amazonaws.services.glue.model.GetPartitionsRequest;
+import com.amazonaws.services.glue.model.GetPartitionsResult;
+import com.amazonaws.services.glue.model.GetTableRequest;
+import com.amazonaws.services.glue.model.GetTableResult;
+import com.amazonaws.services.glue.model.GetTablesRequest;
+import com.amazonaws.services.glue.model.GetTablesResult;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
+import com.amazonaws.services.glue.model.GetUserDefinedFunctionsResult;
+import com.amazonaws.services.glue.model.Partition;
+import com.amazonaws.services.glue.model.PartitionError;
+import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.PartitionValueList;
+import com.amazonaws.services.glue.model.Segment;
+import com.amazonaws.services.glue.model.Table;
+import com.amazonaws.services.glue.model.TableInput;
+import com.amazonaws.services.glue.model.UpdateDatabaseRequest;
+import com.amazonaws.services.glue.model.UpdatePartitionRequest;
+import com.amazonaws.services.glue.model.UpdateTableRequest;
+import com.amazonaws.services.glue.model.UpdateUserDefinedFunctionRequest;
+import com.amazonaws.services.glue.model.UserDefinedFunction;
+import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.thrift.TException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
+
+    public static final int BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE = 1000;
+    /**
+     * Based on the maxResults parameter at https://docs.aws.amazon.com/glue/latest/webapi/API_GetPartitions.html
+     */
+    public static final int GET_PARTITIONS_MAX_SIZE = 1000;
+    /**
+     * Maximum number of Glue Segments. A segment defines a non-overlapping region of a table's partitions,
+     * allowing multiple requests to be executed in parallel.
+     */
+    public static final int DEFAULT_NUM_PARTITION_SEGMENTS = 5;
+    /**
+     * Currently the upper limit allowed by Glue is 10.
+     * https://docs.aws.amazon.com/glue/latest/webapi/API_Segment.html
+     */
+    public static final int MAX_NUM_PARTITION_SEGMENTS = 10;
+    public static final String NUM_PARTITION_SEGMENTS_CONF = "aws.glue.partition.num.segments";
+    public static final String CUSTOM_EXECUTOR_FACTORY_CONF = "hive.metastore.executorservice.factory.class";
+
+    private final HiveConf conf;
+    private final AWSGlue glueClient;
+    private final String catalogId;
+    private final ExecutorService executorService;
+    private final int numPartitionSegments;
+
+    protected ExecutorService getExecutorService(HiveConf hiveConf) {
+        Class<? extends ExecutorServiceFactory> executorFactoryClass = hiveConf
+                .getClass(CUSTOM_EXECUTOR_FACTORY_CONF,
+                        DefaultExecutorServiceFactory.class).asSubclass(
+                        ExecutorServiceFactory.class);
+        ExecutorServiceFactory factory = ReflectionUtils.newInstance(
+                executorFactoryClass, hiveConf);
+        return factory.getExecutorService(hiveConf);
+    }
+
+    public DefaultAWSGlueMetastore(HiveConf conf, AWSGlue glueClient) {
+        checkNotNull(conf, "Hive Config cannot be null");
+        checkNotNull(glueClient, "glueClient cannot be null");
+        this.numPartitionSegments = conf.getInt(NUM_PARTITION_SEGMENTS_CONF, DEFAULT_NUM_PARTITION_SEGMENTS);
+        checkArgument(numPartitionSegments <= MAX_NUM_PARTITION_SEGMENTS,
+                String.format("Hive Config [%s] can't exceed %d", NUM_PARTITION_SEGMENTS_CONF, MAX_NUM_PARTITION_SEGMENTS));
+        this.conf = conf;
+        this.glueClient = glueClient;
+        this.catalogId = MetastoreClientUtils.getCatalogId(conf);
+        this.executorService = getExecutorService(conf);
+    }
+
+    // ======================= Database =======================
+
+    @Override
+    public void createDatabase(DatabaseInput databaseInput) {
+        CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest().withDatabaseInput(databaseInput)
+                .withCatalogId(catalogId);
+        glueClient.createDatabase(createDatabaseRequest);
+    }
+
+    @Override
+    public Database getDatabase(String dbName) {
+        GetDatabaseRequest getDatabaseRequest = new GetDatabaseRequest().withCatalogId(catalogId).withName(dbName);
+        GetDatabaseResult result = glueClient.getDatabase(getDatabaseRequest);
+        return result.getDatabase();
+    }
+
+    @Override
+    public List<Database> getAllDatabases() {
+        List<Database> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetDatabasesRequest getDatabasesRequest = new GetDatabasesRequest().withNextToken(nextToken).withCatalogId(
+                    catalogId);
+            GetDatabasesResult result = glueClient.getDatabases(getDatabasesRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getDatabaseList());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateDatabase(String databaseName, DatabaseInput databaseInput) {
+        UpdateDatabaseRequest updateDatabaseRequest = new UpdateDatabaseRequest().withName(databaseName)
+                .withDatabaseInput(databaseInput).withCatalogId(catalogId);
+        glueClient.updateDatabase(updateDatabaseRequest);
+    }
+
+    @Override
+    public void deleteDatabase(String dbName) {
+        DeleteDatabaseRequest deleteDatabaseRequest = new DeleteDatabaseRequest().withName(dbName).withCatalogId(
+                catalogId);
+        glueClient.deleteDatabase(deleteDatabaseRequest);
+    }
+
+    // ======================== Table ========================
+
+    @Override
+    public void createTable(String dbName, TableInput tableInput) {
+        CreateTableRequest createTableRequest = new CreateTableRequest().withTableInput(tableInput)
+                .withDatabaseName(dbName).withCatalogId(catalogId);
+        glueClient.createTable(createTableRequest);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) {
+        GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        GetTableResult result = glueClient.getTable(getTableRequest);
+        return result.getTable();
+    }
+
+    @Override
+    public List<Table> getTables(String dbname, String tablePattern) {
+        List<Table> ret = new ArrayList<>();
+        String nextToken = null;
+        do {
+            GetTablesRequest getTablesRequest = new GetTablesRequest().withDatabaseName(dbname)
+                    .withExpression(tablePattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetTablesResult result = glueClient.getTables(getTablesRequest);
+            ret.addAll(result.getTableList());
+            nextToken = result.getNextToken();
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void updateTable(String dbName, TableInput tableInput) {
+        UpdateTableRequest updateTableRequest = new UpdateTableRequest().withDatabaseName(dbName)
+                .withTableInput(tableInput).withCatalogId(catalogId);
+        glueClient.updateTable(updateTableRequest);
+    }
+
+    @Override
+    public void deleteTable(String dbName, String tableName) {
+        DeleteTableRequest deleteTableRequest = new DeleteTableRequest().withDatabaseName(dbName).withName(tableName)
+                .withCatalogId(catalogId);
+        glueClient.deleteTable(deleteTableRequest);
+    }
+
+    // =========================== Partition ===========================
+
+    @Override
+    public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
+        GetPartitionRequest request = new GetPartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        return glueClient.getPartition(request).getPartition();
+    }
+
+    @Override
+    public List<Partition> getPartitionsByNames(String dbName, String tableName,
+                                                List<PartitionValueList> partitionsToGet) {
+
+        List<List<PartitionValueList>> batchedPartitionsToGet = Lists.partition(partitionsToGet,
+                BATCH_GET_PARTITIONS_MAX_REQUEST_SIZE);
+        List<Future<BatchGetPartitionResult>> batchGetPartitionFutures = Lists.newArrayList();
+
+        for (List<PartitionValueList> batch : batchedPartitionsToGet) {
+            final BatchGetPartitionRequest request = new BatchGetPartitionRequest()
+                    .withDatabaseName(dbName)
+                    .withTableName(tableName)
+                    .withPartitionsToGet(batch)
+                    .withCatalogId(catalogId);
+            batchGetPartitionFutures.add(this.executorService.submit(new Callable<BatchGetPartitionResult>() {
+                @Override
+                public BatchGetPartitionResult call() throws Exception {
+                    return glueClient.batchGetPartition(request);
+                }
+            }));
+        }
+
+        List<Partition> result = Lists.newArrayList();
+        try {
+            for (Future<BatchGetPartitionResult> future : batchGetPartitionFutures) {
+                result.addAll(future.get().getPartitions());
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return result;
+    }
+
+    @Override
+    public List<Partition> getPartitions(String dbName, String tableName, String expression,
+                                         long max) throws TException {
+        if (max == 0) {
+            return Collections.emptyList();
+        }
+        if (max < 0 || max > GET_PARTITIONS_MAX_SIZE) {
+            return getPartitionsParallel(dbName, tableName, expression, max);
+        } else {
+            // We don't need to get too many partitions, so just do it serially.
+            return getCatalogPartitions(dbName, tableName, expression, max, null);
+        }
+    }
+
+    private List<Partition> getPartitionsParallel(
+            final String databaseName,
+            final String tableName,
+            final String expression,
+            final long max) throws TException {
+        // Prepare the segments
+        List<Segment> segments = Lists.newArrayList();
+        for (int i = 0; i < numPartitionSegments; i++) {
+            segments.add(new Segment()
+                    .withSegmentNumber(i)
+                    .withTotalSegments(numPartitionSegments));
+        }
+        // Submit Glue API calls in parallel using the thread pool.
+        // We could convert this into a parallelStream after upgrading to JDK 8 compiler base.
+        List<Future<List<Partition>>> futures = Lists.newArrayList();
+        for (final Segment segment : segments) {
+            futures.add(this.executorService.submit(new Callable<List<Partition>>() {
+                @Override
+                public List<Partition> call() throws Exception {
+                    return getCatalogPartitions(databaseName, tableName, expression, max, segment);
+                }
+            }));
+        }
+
+        // Get the results
+        List<Partition> partitions = Lists.newArrayList();
+        try {
+            for (Future<List<Partition>> future : futures) {
+                List<Partition> segmentPartitions = future.get();
+                if (partitions.size() + segmentPartitions.size() >= max && max > 0) {
+                    // Extract the required number of partitions from the segment and we're done.
+                    long remaining = max - partitions.size();
+                    partitions.addAll(segmentPartitions.subList(0, (int) remaining));
+                    break;
+                } else {
+                    partitions.addAll(segmentPartitions);
+                }
+            }
+        } catch (ExecutionException e) {
+            Throwables.propagateIfInstanceOf(e.getCause(), AmazonServiceException.class);
+            Throwables.propagate(e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return partitions;
+    }
+
+
+    private List<Partition> getCatalogPartitions(String databaseName, String tableName, String expression,
+                                                 long max, Segment segment) {
+        List<Partition> partitions = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetPartitionsRequest request = new GetPartitionsRequest()
+                    .withDatabaseName(databaseName)
+                    .withTableName(tableName)
+                    .withExpression(expression)
+                    .withNextToken(nextToken)
+                    .withCatalogId(catalogId)
+                    .withSegment(segment);
+            GetPartitionsResult res = glueClient.getPartitions(request);
+            List<Partition> list = res.getPartitions();
+            if ((partitions.size() + list.size()) >= max && max > 0) {
+                long remaining = max - partitions.size();
+                partitions.addAll(list.subList(0, (int) remaining));
+                break;
+            }
+            partitions.addAll(list);
+            nextToken = res.getNextToken();
+        } while (nextToken != null);
+        return partitions;
+    }
+
+    @Override
+    public void updatePartition(String dbName, String tableName, List<String> partitionValues,
+                                PartitionInput partitionInput) {
+        UpdatePartitionRequest updatePartitionRequest = new UpdatePartitionRequest().withDatabaseName(dbName)
+                .withTableName(tableName).withPartitionValueList(partitionValues)
+                .withPartitionInput(partitionInput).withCatalogId(catalogId);
+        glueClient.updatePartition(updatePartitionRequest);
+    }
+
+    @Override
+    public void deletePartition(String dbName, String tableName, List<String> partitionValues) {
+        DeletePartitionRequest request = new DeletePartitionRequest()
+                .withDatabaseName(dbName)
+                .withTableName(tableName)
+                .withPartitionValues(partitionValues)
+                .withCatalogId(catalogId);
+        glueClient.deletePartition(request);
+    }
+
+    @Override
+    public List<PartitionError> createPartitions(String dbName, String tableName,
+                                                 List<PartitionInput> partitionInputs) {
+        BatchCreatePartitionRequest request =
+                new BatchCreatePartitionRequest().withDatabaseName(dbName)
+                .withTableName(tableName).withCatalogId(catalogId)
+                .withPartitionInputList(partitionInputs);
+        return glueClient.batchCreatePartition(request).getErrors();
+    }
+
+    // ====================== User Defined Function ======================
+
+    @Override
+    public void createUserDefinedFunction(String dbName, UserDefinedFunctionInput functionInput) {
+        CreateUserDefinedFunctionRequest createUserDefinedFunctionRequest = new CreateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionInput(functionInput).withCatalogId(catalogId);
+        glueClient.createUserDefinedFunction(createUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public UserDefinedFunction getUserDefinedFunction(String dbName, String functionName) {
+        GetUserDefinedFunctionRequest getUserDefinedFunctionRequest = new GetUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        return glueClient.getUserDefinedFunction(getUserDefinedFunctionRequest).getUserDefinedFunction();
+    }
+
+    @Override
+    public List<UserDefinedFunction> getUserDefinedFunctions(String dbName, String pattern) {
+        List<UserDefinedFunction> ret = Lists.newArrayList();
+        String nextToken = null;
+        do {
+            GetUserDefinedFunctionsRequest getUserDefinedFunctionsRequest = new GetUserDefinedFunctionsRequest()
+                    .withDatabaseName(dbName).withPattern(pattern).withNextToken(nextToken).withCatalogId(catalogId);
+            GetUserDefinedFunctionsResult result = glueClient.getUserDefinedFunctions(getUserDefinedFunctionsRequest);
+            nextToken = result.getNextToken();
+            ret.addAll(result.getUserDefinedFunctions());
+        } while (nextToken != null);
+        return ret;
+    }
+
+    @Override
+    public void deleteUserDefinedFunction(String dbName, String functionName) {
+        DeleteUserDefinedFunctionRequest deleteUserDefinedFunctionRequest = new DeleteUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+        glueClient.deleteUserDefinedFunction(deleteUserDefinedFunctionRequest);
+    }
+
+    @Override
+    public void updateUserDefinedFunction(String dbName, String functionName, UserDefinedFunctionInput functionInput) {
+        UpdateUserDefinedFunctionRequest updateUserDefinedFunctionRequest = new UpdateUserDefinedFunctionRequest()
+                .withDatabaseName(dbName).withFunctionName(functionName).withFunctionInput(functionInput)
+                .withCatalogId(catalogId);
+        glueClient.updateUserDefinedFunction(updateUserDefinedFunctionRequest);
+    }
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/AWSGlueConfig.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/AWSGlueConfig.java
@@ -22,4 +22,12 @@ public final class AWSGlueConfig {
 
   public static final String AWS_GLUE_SOCKET_TIMEOUT = "aws.glue.socket-timeout";
   public static final int DEFAULT_SOCKET_TIMEOUT = ClientConfiguration.DEFAULT_SOCKET_TIMEOUT;
+
+  public static final String AWS_GLUE_DB_CACHE_ENABLE = "aws.glue.cache.db.enable";
+  public static final String AWS_GLUE_DB_CACHE_SIZE = "aws.glue.cache.db.size";
+  public static final String AWS_GLUE_DB_CACHE_TTL_MINS = "aws.glue.cache.db.ttl-mins";
+
+  public static final String AWS_GLUE_TABLE_CACHE_ENABLE = "aws.glue.cache.table.enable";
+  public static final String AWS_GLUE_TABLE_CACHE_SIZE = "aws.glue.cache.table.size";
+  public static final String AWS_GLUE_TABLE_CACHE_TTL_MINS = "aws.glue.cache.table.ttl-mins";
 }

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/BatchCreatePartitionsHelper.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/BatchCreatePartitionsHelper.java
@@ -1,18 +1,14 @@
 package com.amazonaws.glue.catalog.util;
 
+import com.amazonaws.glue.catalog.metastore.AWSGlueMetastore;
 import com.amazonaws.glue.catalog.converters.CatalogToHiveConverter;
 import com.amazonaws.glue.catalog.converters.GlueInputConverter;
-import com.amazonaws.services.glue.model.BatchCreatePartitionRequest;
-import com.amazonaws.services.glue.model.BatchCreatePartitionResult;
 import com.amazonaws.services.glue.model.EntityNotFoundException;
-import com.amazonaws.services.glue.model.GetPartitionRequest;
-import com.amazonaws.services.glue.model.GetPartitionResult;
 import com.amazonaws.services.glue.model.Partition;
 import com.amazonaws.services.glue.model.PartitionError;
-import com.amazonaws.services.glue.AWSGlue;
 import com.google.common.collect.Lists;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
@@ -27,7 +23,7 @@ public final class BatchCreatePartitionsHelper {
 
   private static final Logger logger = Logger.getLogger(BatchCreatePartitionsHelper.class);
 
-  private final AWSGlue client;
+  private final AWSGlueMetastore glueClient;
   private final String databaseName;
   private final String tableName;
   private final List<Partition> partitions;
@@ -37,9 +33,9 @@ public final class BatchCreatePartitionsHelper {
   private TException firstTException;
   private String catalogId;
 
-  public BatchCreatePartitionsHelper(AWSGlue client, String databaseName, String tableName, String catalogId,
+  public BatchCreatePartitionsHelper(AWSGlueMetastore glueClient, String databaseName, String tableName, String catalogId,
                                      List<Partition> partitions, boolean ifNotExists) {
-    this.client = client;
+    this.glueClient = glueClient;
     this.databaseName = databaseName;
     this.tableName = tableName;
     this.catalogId = catalogId;
@@ -51,14 +47,10 @@ public final class BatchCreatePartitionsHelper {
     partitionMap = PartitionUtils.buildPartitionMap(partitions);
     partitionsFailed = Lists.newArrayList();
 
-    BatchCreatePartitionRequest request = new BatchCreatePartitionRequest()
-        .withDatabaseName(databaseName)
-        .withTableName(tableName)
-        .withCatalogId(catalogId)
-        .withPartitionInputList(GlueInputConverter.convertToPartitionInputs(partitionMap.values()));
-    
     try {
-      BatchCreatePartitionResult result = client.batchCreatePartition(request);
+      List<PartitionError> result =
+              glueClient.createPartitions(databaseName, tableName,
+                      GlueInputConverter.convertToPartitionInputs(partitionMap.values()));
       processResult(result);
     } catch (Exception e) {
       logger.error("Exception thrown while creating partitions in DataCatalog: ", e);
@@ -77,8 +69,7 @@ public final class BatchCreatePartitionsHelper {
     partitionMap.clear();
   }
 
-  private void processResult(BatchCreatePartitionResult result) {
-    List<PartitionError> partitionErrors = result.getErrors();
+  private void processResult(List<PartitionError> partitionErrors) {
     if (partitionErrors == null || partitionErrors.isEmpty()) {
       return;
     }
@@ -112,21 +103,16 @@ public final class BatchCreatePartitionsHelper {
   }
 
   private boolean partitionExists(Partition partition) {
-    GetPartitionRequest request = new GetPartitionRequest()
-        .withDatabaseName(partition.getDatabaseName())
-        .withTableName(partition.getTableName())
-        .withCatalogId(catalogId)
-        .withPartitionValues(partition.getValues());
     
     try {
-      GetPartitionResult result = client.getPartition(request);
-      Partition partitionReturned = result.getPartition();
+      Partition partitionReturned = glueClient.getPartition(databaseName, tableName, partition.getValues());
       return partitionReturned != null; //probably always true here
     } catch (EntityNotFoundException e) {
       // here we assume namespace and table exist. It is assured by calling "isInvalidUserInputException" method above
       return false;
     } catch (Exception e) {
-      logger.error(String.format("Get partition request %s failed. ", request.toString()), e);
+      logger.error(String.format("Get partition request %s failed. ",
+              StringUtils.join(partition.getValues(), "/")), e);
       // partition status unknown, we assume that the partition was not created
       return false;
     }

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecoratorTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreCacheDecoratorTest.java
@@ -1,0 +1,178 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import com.amazonaws.services.glue.model.Database;
+import com.amazonaws.services.glue.model.Table;
+import com.google.common.cache.Cache;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+
+public class AWSGlueMetastoreCacheDecoratorTest {
+
+    private AWSGlueMetastore glueMetastore;
+    private HiveConf hiveConf;
+
+    private static final String DB_NAME = "db";
+    private static final String TABLE_NAME = "table";
+    private static final AWSGlueMetastoreCacheDecorator.TableIdentifier TABLE_IDENTIFIER =
+            new AWSGlueMetastoreCacheDecorator.TableIdentifier(DB_NAME, TABLE_NAME);
+
+    @Before
+    public void setUp() {
+        glueMetastore = mock(AWSGlueMetastore.class);
+        hiveConf = spy(new HiveConf());
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(100);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(100);
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructorWithNullConf() {
+        new AWSGlueMetastoreCacheDecorator(null, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidTableCacheSize() {
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidTableCacheTtl() {
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidDbCacheSize() {
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorWithInvalidDbCacheTtl() {
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(0);
+        new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheDisabled() {
+        //disable cache
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        when(glueMetastore.getDatabase(DB_NAME)).thenReturn(db);
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+        assertNull(cacheDecorator.databaseCache);
+        verify(glueMetastore, times(1)).getDatabase(DB_NAME);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheEnabledAndCacheMiss() {
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.databaseCache);
+        Cache dbCache = mock(Cache.class);
+        cacheDecorator.databaseCache = dbCache;
+
+        when(dbCache.getIfPresent(DB_NAME)).thenReturn(null);
+        when(glueMetastore.getDatabase(DB_NAME)).thenReturn(db);
+        doNothing().when(dbCache).put(DB_NAME, db);
+
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+
+        verify(glueMetastore, times(1)).getDatabase(DB_NAME);
+        verify(dbCache, times(1)).getIfPresent(DB_NAME);
+        verify(dbCache, times(1)).put(DB_NAME, db);
+    }
+
+    @Test
+    public void testGetDatabaseWhenCacheEnabledAndCacheHit() {
+        Database db = new Database();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.databaseCache);
+        Cache dbCache = mock(Cache.class);
+        cacheDecorator.databaseCache = dbCache;
+
+        when(dbCache.getIfPresent(DB_NAME)).thenReturn(db);
+
+        assertEquals(db, cacheDecorator.getDatabase(DB_NAME));
+
+        verify(dbCache, times(1)).getIfPresent(DB_NAME);
+    }
+
+    @Test
+    public void testGetTableWhenCacheDisabled() {
+        //disable cache
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(false);
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        when(glueMetastore.getTable(DB_NAME, TABLE_NAME)).thenReturn(table);
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+        assertNull(cacheDecorator.tableCache);
+        verify(glueMetastore, times(1)).getTable(DB_NAME, TABLE_NAME);
+    }
+
+    @Test
+    public void testGetTableWhenCacheEnabledAndCacheMiss() {
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.tableCache);
+        Cache tableCache = mock(Cache.class);
+        cacheDecorator.tableCache = tableCache;
+
+        when(tableCache.getIfPresent(TABLE_IDENTIFIER)).thenReturn(null);
+        when(glueMetastore.getTable(DB_NAME, TABLE_NAME)).thenReturn(table);
+        doNothing().when(tableCache).put(TABLE_IDENTIFIER, table);
+
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+
+        verify(glueMetastore, times(1)).getTable(DB_NAME, TABLE_NAME);
+        verify(tableCache, times(1)).getIfPresent(TABLE_IDENTIFIER);
+        verify(tableCache, times(1)).put(TABLE_IDENTIFIER, table);
+    }
+
+    @Test
+    public void testGetTableWhenCacheEnabledAndCacheHit() {
+        Table table = new Table();
+        AWSGlueMetastoreCacheDecorator cacheDecorator =
+                new AWSGlueMetastoreCacheDecorator(hiveConf, glueMetastore);
+        assertNotNull(cacheDecorator.tableCache);
+        Cache tableCache = mock(Cache.class);
+        cacheDecorator.tableCache = tableCache;
+
+        when(tableCache.getIfPresent(TABLE_IDENTIFIER)).thenReturn(table);
+
+        assertEquals(table, cacheDecorator.getTable(DB_NAME, TABLE_NAME));
+
+        verify(tableCache, times(1)).getIfPresent(TABLE_IDENTIFIER);
+    }
+
+}

--- a/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactoryTest.java
+++ b/aws-glue-datacatalog-client-common/src/test/java/com/amazonaws/glue/catalog/metastore/AWSGlueMetastoreFactoryTest.java
@@ -1,0 +1,84 @@
+package com.amazonaws.glue.catalog.metastore;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_ENABLE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_ENDPOINT;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_TABLE_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_SIZE;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_GLUE_DB_CACHE_TTL_MINS;
+import static com.amazonaws.glue.catalog.util.AWSGlueConfig.AWS_REGION;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
+
+public class AWSGlueMetastoreFactoryTest {
+
+    private AWSGlueMetastoreFactory awsGlueMetastoreFactory;
+    private HiveConf hiveConf;
+
+    @Before
+    public void setUp() {
+        awsGlueMetastoreFactory = new AWSGlueMetastoreFactory();
+        hiveConf = spy(new HiveConf());
+
+        // these configs are needed for AWSGlueClient to get initialized
+        System.setProperty(AWS_REGION, "");
+        System.setProperty(AWS_GLUE_ENDPOINT, "");
+        when(hiveConf.get(AWS_GLUE_ENDPOINT)).thenReturn("endpoint");
+        when(hiveConf.get(AWS_REGION)).thenReturn("us-west-1");
+
+        // these configs are needed for AWSGlueMetastoreCacheDecorator to get initialized
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_SIZE, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_DB_CACHE_TTL_MINS, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_SIZE, 0)).thenReturn(1);
+        when(hiveConf.getInt(AWS_GLUE_TABLE_CACHE_TTL_MINS, 0)).thenReturn(1);
+    }
+
+    @Test
+    public void testNewMetastoreWhenCacheDisabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(false);
+        assertTrue(DefaultAWSGlueMetastore.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenTableCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(false);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenDBCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+    @Test
+    public void testNewMetastoreWhenAllCacheEnabled() throws Exception {
+        when(hiveConf.getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false)).thenReturn(true);
+        when(hiveConf.getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false)).thenReturn(true);
+        assertTrue(AWSGlueMetastoreCacheDecorator.class.equals(
+                awsGlueMetastoreFactory.newMetastore(hiveConf).getClass()));
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_DB_CACHE_ENABLE, false);
+        verify(hiveConf, atLeastOnce()).getBoolean(AWS_GLUE_TABLE_CACHE_ENABLE, false);
+    }
+
+}

--- a/aws-glue-datacatalog-hive2-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
+++ b/aws-glue-datacatalog-hive2-client/src/main/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClient.java
@@ -12,23 +12,13 @@ import com.amazonaws.glue.shims.AwsGlueHiveShims;
 import com.amazonaws.glue.shims.ShimsLoader;
 import com.amazonaws.services.glue.AWSGlue;
 import com.amazonaws.services.glue.model.AlreadyExistsException;
-import com.amazonaws.services.glue.model.Column;
-import com.amazonaws.services.glue.model.CreateUserDefinedFunctionRequest;
-import com.amazonaws.services.glue.model.DeleteUserDefinedFunctionRequest;
 import com.amazonaws.services.glue.model.EntityNotFoundException;
 import com.amazonaws.services.glue.model.GetDatabaseRequest;
-import com.amazonaws.services.glue.model.GetTableRequest;
-import com.amazonaws.services.glue.model.GetTableResult;
-import com.amazonaws.services.glue.model.GetUserDefinedFunctionRequest;
-import com.amazonaws.services.glue.model.GetUserDefinedFunctionResult;
 import com.amazonaws.services.glue.model.GetUserDefinedFunctionsRequest;
-import com.amazonaws.services.glue.model.GetUserDefinedFunctionsResult;
 import com.amazonaws.services.glue.model.Partition;
 import com.amazonaws.services.glue.model.Table;
 import com.amazonaws.services.glue.model.UpdatePartitionRequest;
-import com.amazonaws.services.glue.model.UpdateUserDefinedFunctionRequest;
 import com.amazonaws.services.glue.model.UserDefinedFunction;
-import com.amazonaws.services.glue.model.UserDefinedFunctionInput;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -150,10 +140,6 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
   private Map<String, String> currentMetaVars;
   private final AwsGlueHiveShims hiveShims = ShimsLoader.getHiveShims();
 
-  public AWSCatalogMetastoreClient(HiveConf conf) throws MetaException {
-    this(conf, null);
-  }
-
   public AWSCatalogMetastoreClient(HiveConf conf, HiveMetaHookLoader hook) throws MetaException {
     this.conf = conf;
     glueClient = new AWSGlueClientFactory(this.conf).newClient();
@@ -161,7 +147,8 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     // TODO preserve existing functionality for HiveMetaHook
     wh = new Warehouse(this.conf);
 
-    glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueClient, wh);
+    AWSGlueMetastore glueMetastore = new AWSGlueMetastoreFactory().newMetastore(conf);
+    glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueMetastore, wh);
 
     snapshotActiveConf();
     catalogId = MetastoreClientUtils.getCatalogId(conf);
@@ -178,6 +165,7 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     private HiveConf conf;
     private Warehouse wh;
     private GlueClientFactory clientFactory;
+    private AWSGlueMetastoreFactory metastoreFactory;
     private boolean createDefaults = true;
     private String catalogId;
 
@@ -188,6 +176,11 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
 
     public Builder withClientFactory(GlueClientFactory clientFactory) {
       this.clientFactory = clientFactory;
+      return this;
+    }
+
+    public Builder withMetastoreFactory(AWSGlueMetastoreFactory metastoreFactory) {
+      this.metastoreFactory = metastoreFactory;
       return this;
     }
 
@@ -227,8 +220,12 @@ public class AWSCatalogMetastoreClient implements IMetaStoreClient {
     }
 
     GlueClientFactory clientFactory = Objects.firstNonNull(builder.clientFactory, new AWSGlueClientFactory(conf));
+    AWSGlueMetastoreFactory metastoreFactory = Objects.firstNonNull(builder.metastoreFactory,
+            new AWSGlueMetastoreFactory());
+
     glueClient = clientFactory.newClient();
-    glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueClient, wh);
+    AWSGlueMetastore glueMetastore = metastoreFactory.newMetastore(conf);
+    glueMetastoreClientDelegate = new GlueMetastoreClientDelegate(this.conf, glueMetastore, wh);
 
     /**
      * It seems weird to create databases as part of client construction. This

--- a/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClientTest.java
+++ b/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/AWSCatalogMetastoreClientTest.java
@@ -122,6 +122,7 @@ public class AWSCatalogMetastoreClientTest {
   private Warehouse wh;
   private HiveConf conf;
   private GlueClientFactory clientFactory;
+  private AWSGlueMetastoreFactory metastoreFactory;
   private final AwsGlueHiveShims hiveShims = ShimsLoader.getHiveShims();
 
   // Test objects
@@ -152,9 +153,11 @@ public class AWSCatalogMetastoreClientTest {
     conf.setInt(GlueMetastoreClientDelegate.NUM_PARTITION_SEGMENTS_CONF, 1);
     glueClient = spy(AWSGlue.class);
     clientFactory = mock(GlueClientFactory.class);
+    metastoreFactory = mock(AWSGlueMetastoreFactory.class);
     when(clientFactory.newClient()).thenReturn(glueClient);
+    when(metastoreFactory.newMetastore(conf)).thenReturn(new DefaultAWSGlueMetastore(conf, glueClient));
     metastoreClient = new AWSCatalogMetastoreClient.Builder().withClientFactory(clientFactory)
-        .withWarehouse(wh).createDefaults(false).withHiveConf(conf).build();
+        .withMetastoreFactory(metastoreFactory).withWarehouse(wh).createDefaults(false).withHiveConf(conf).build();
   }
 
   private void setupMockWarehouseForPath(Path path, boolean isDir, boolean isDefaultDbPath) throws MetaException {
@@ -172,7 +175,7 @@ public class AWSCatalogMetastoreClientTest {
 
     when(conf.getVar(conf, ConfVars.USERS_IN_ADMIN_ROLE, "")).thenReturn("");
     metastoreClient = new AWSCatalogMetastoreClient.Builder().withClientFactory(clientFactory)
-        .withWarehouse(wh).createDefaults(true).withHiveConf(conf).build();
+        .withMetastoreFactory(metastoreFactory).withWarehouse(wh).createDefaults(true).withHiveConf(conf).build();
 
     verify(glueClient, times(1)).createDatabase(any(CreateDatabaseRequest.class));
     verify(wh, times(1)).getDefaultDatabasePath(DEFAULT_DATABASE_NAME);

--- a/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/integrationtest/MetastoreClientTableIntegrationTest.java
+++ b/aws-glue-datacatalog-spark-client/src/test/java/com/amazonaws/glue/catalog/metastore/integrationtest/MetastoreClientTableIntegrationTest.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws.glue</groupId>
   <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-  <version>1.10.0-SNAPSHOT</version>
+  <version>1.11.0</version>
     <modules>
       <module>aws-glue-datacatalog-client-common</module>
       <module>aws-glue-datacatalog-spark-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -19,17 +19,17 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>14.0.1</guava.version>
-    <hive2.version>2.3.3</hive2.version>
+    <hive2.version>2.3.7</hive2.version>
     <spark-hive.version>1.2.1</spark-hive.version>
     <aws.sdk.version>1.11.267</aws.sdk.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <surefire.version>2.15</surefire.version>
     <powermock.version>1.6.4</powermock.version>
-    <hadoop.version>2.8.3</hadoop.version>
+    <hadoop.version>3.2.0</hadoop.version>
     <maven.eclipse.plugin.version>2.9</maven.eclipse.plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <httpclient.version>4.5.3</httpclient.version>
+    <httpclient.version>4.5.11</httpclient.version>
     <guava.version>28.2-jre</guava.version>
     <checkstyle.config.location>${basedir}/dev-support/check_style.xml</checkstyle.config.location>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <maven.eclipse.plugin.version>2.9</maven.eclipse.plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.3</httpclient.version>
+    <guava.version>28.2-jre</guava.version>
     <checkstyle.config.location>${basedir}/dev-support/check_style.xml</checkstyle.config.location>
   </properties>
 


### PR DESCRIPTION
*  Spark3 업데이트와 함께 hadoop 3.2, hive 2.3.7 을 사용하도록 변경하여 이를 glue data catalog에도 반영합니다. (+ httpClient 도 4.5.11로 업데이트)

* upstream의 변경 사항을 반영합니다.
  * glue database / table에 대한 캐싱 옵션이 추가되었습니다.

필수 리뷰어: @wflyer 